### PR TITLE
Add support for a logger

### DIFF
--- a/named_stopwatch.go
+++ b/named_stopwatch.go
@@ -33,12 +33,17 @@ import (
 	"time"
 )
 
+type logger interface {
+	Warning(args ...interface{})
+}
+
 // NamedStopwatch holds a map of string named stopwatches. Intended
 // to be used when several Stopwatches are being used at once, and
 // easy to use as they are name based.
 type NamedStopwatch struct {
 	sync.RWMutex
 	stopwatches map[string](*Stopwatch)
+	logger      logger
 }
 
 // NewNamedStopwatch creates an empty Stopwatch list
@@ -163,8 +168,8 @@ func (ns *NamedStopwatch) stop(name string) {
 	if s, ok := ns.stopwatches[name]; ok {
 		if s.IsRunning() {
 			s.Stop()
-		} else {
-			fmt.Printf("WARNING: NamedStopwatch.Stop(%q) IsRunning is false\n", name)
+		} else if ns.logger != nil {
+			ns.logger.Warning("NamedStopwatch.Stop(%q) IsRunning is false\n", name)
 		}
 	}
 }
@@ -269,4 +274,9 @@ func (ns *NamedStopwatch) AddElapsedSince(name string, t time.Time) {
 	if s, ok := ns.stopwatches[name]; ok {
 		s.AddElapsedSince(t)
 	}
+}
+
+// SetLogger is used to set the logger interface
+func (ns *NamedStopwatch) SetLogger(logger logger) {
+	ns.logger = logger
 }

--- a/named_stopwatch_test.go
+++ b/named_stopwatch_test.go
@@ -91,3 +91,28 @@ func TestAddManyNamedStopwatch(t *testing.T) {
 		}
 	}
 }
+
+func TestLogger(t *testing.T) {
+	n1 := NewNamedStopwatch()
+	log := &mockLogger{}
+
+	// Make sure we dont panic
+	n1.Add("loggerTest")
+	n1.stop("loggerTest")
+
+	n1.SetLogger(log)
+	n1.stop("loggerTest")
+
+	if log.logged == false {
+		t.Errorf("Expected logger to be called")
+	}
+
+}
+
+type mockLogger struct {
+	logged bool
+}
+
+func (m *mockLogger) Warning(args ...interface{}) {
+	m.logged = true
+}


### PR DESCRIPTION
Because stopwatch emits a `fmt.Printf` it clutters up the logs of orchestrator.  This move allows us to use a logger or alternatively use no logger and hide the warnings to reduce the clutter of orchestrator logs.  